### PR TITLE
docs: document licensing and concurrency flow

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andre Luiz de Paula Leite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ParrotInc SquawkService
 
+[![CI](https://github.com/andreluizleite/ParrotInc.SquawkService/actions/workflows/ci.yml/badge.svg)](https://github.com/andreluizleite/ParrotInc.SquawkService/actions/workflows/ci.yml)
+[![.NET 10](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
+[![Release](https://img.shields.io/github/v/release/andreluizleite/ParrotInc.SquawkService)](https://github.com/andreluizleite/ParrotInc.SquawkService/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A focused .NET service that demonstrates how deterministic business rules, CQRS, domain modeling, and concurrency-safe in-memory infrastructure can work together without unnecessary distributed-system complexity.
 
 The fictional ParrotInc platform allows users to publish short messages called **squawks**.
@@ -47,6 +52,34 @@ flowchart LR
 ```
 
 The repository and expiring key store are registered as singletons intentionally. They represent the process-local infrastructure of this sample and preserve state across HTTP requests.
+
+### Concurrency-safe creation flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Handler as Create command handler
+    participant Guard as Atomic expiring-key guard
+    participant Domain
+    participant Repository
+
+    Client->>API: POST /api/squawks
+    API->>Handler: Send command
+    Handler->>Guard: Reserve cooldown and content keys
+    alt Reservation rejected
+        Guard-->>Handler: Duplicate or cooldown violation
+        Handler-->>API: Deterministic rule exception
+        API-->>Client: Problem Details (409 or 429)
+    else Reservation accepted
+        Handler->>Domain: Create validated squawk
+        Domain->>Repository: Persist in process-local store
+        Handler-->>API: Created squawk
+        API-->>Client: 201 Created
+    end
+```
+
+The reservation is atomic: concurrent requests from the same user cannot both pass the duplicate and cooldown checks. In a multi-instance deployment, this guard would move to a shared store such as Redis while the deterministic rule contract remained unchanged.
 
 ## API
 


### PR DESCRIPTION
## Summary
- add an explicit MIT license
- add CI, .NET, release and license badges
- document the atomic concurrency-safe creation flow with a Mermaid sequence diagram
- keep persistent/distributed infrastructure outside the sample scope

## Verification
- git diff --check
- documentation-only change; no runtime behavior changed

Part of #15
